### PR TITLE
Adding linear activation function to end of YOLO definition to enable…

### DIFF
--- a/src/main/java/org/ml4j/nn/architectures/yolo/yolov2/YOLOv2Definition.java
+++ b/src/main/java/org/ml4j/nn/architectures/yolo/yolov2/YOLOv2Definition.java
@@ -423,7 +423,10 @@ public class YOLOv2Definition implements Component3Dto3DGraphDefinition {
 				.withBiasUnit()
 				.withBiases(weightsLoader.getConvolutionalLayerBiases("conv2d_23_bias0", 425))
 				.withSamePadding()
-				.withConnectionToNeurons(new Neurons3D(19, 19, 425, false));
+				.withConnectionToNeurons(new Neurons3D(19, 19, 425, false)) // End with a linear activation function so that this 
+				// // End with a linear activation function so that this definition can be used as a neural network.
+				.withActivationFunction("noOpActivationFunction", ActivationFunctionType.getBaseType(ActivationFunctionBaseType.LINEAR), 
+						new ActivationFunctionProperties());
 	}
 	
 	@Override

--- a/src/test/java/org/ml4j/nn/architectures/yolo/yolov2/YOLOv2DefinitionMetadataExtractionTest.java
+++ b/src/test/java/org/ml4j/nn/architectures/yolo/yolov2/YOLOv2DefinitionMetadataExtractionTest.java
@@ -36,7 +36,7 @@ public class YOLOv2DefinitionMetadataExtractionTest extends YOLOv2DefinitionTest
 		
 		List<ComponentMetadata> sequentialComponents = componentGraph.getComponents();
 		
-		Assert.assertEquals(48, sequentialComponents.size());
+		Assert.assertEquals(49, sequentialComponents.size());
 		
 		for (ComponentMetadata component : sequentialComponents) {
 			LOGGER.debug(component.toString());

--- a/src/test/java/org/ml4j/nn/architectures/yolo/yolov2/YOLOv2DefinitionTest.java
+++ b/src/test/java/org/ml4j/nn/architectures/yolo/yolov2/YOLOv2DefinitionTest.java
@@ -49,7 +49,7 @@ public class YOLOv2DefinitionTest extends YOLOv2DefinitionTestBase<DefaultChaina
 		
 		List<DefaultChainableDirectedComponent<?, ?>> sequentialComponents = componentGraph.getComponents();
 		
-		Assert.assertEquals(48, sequentialComponents.size());
+		Assert.assertEquals(49, sequentialComponents.size());
 	
 		int index = 0;
 	


### PR DESCRIPTION
… it's use in net which requires chains to end with activation functions